### PR TITLE
Automatically build image

### DIFF
--- a/typescript/ecs-go-api/index.ts
+++ b/typescript/ecs-go-api/index.ts
@@ -21,7 +21,7 @@ export default class EcsGoAPIStack extends cdk.Stack {
         const cluster = new ecs.Cluster(this, 'Cluster', { vpc });
         const fargateService = new ecs_patterns.LoadBalancedFargateService(this, "FargateService", {
             cluster,
-            image: new ecs.EcrImage(ecrRepo, "latest"),
+            image: new ecs.ContainerImage.fromAsset("api"),
             containerPort: 8080
         });
         new cdk.CfnOutput(this, 'LoadBalancerDNS', { value: fargateService.loadBalancer.loadBalancerDnsName });


### PR DESCRIPTION
With this change there is no longer any need to manually create an ECR repo, and manually build and push your Docker image. Instead CDK will automatically build the image using the Dockerfile in the "api" directory, automatically create an ECR repo and push the image, and then use it in the Fargate service.