### PR TITLE
Fix backwards non-compatible code in Serverless-EKS

### DIFF
--- a/serverless-eks/index.ts
+++ b/serverless-eks/index.ts
@@ -27,6 +27,7 @@ class ServerlessEKSStack extends cdk.Stack {
         })
 
         const cluster = new eks.FargateCluster(this, "fargate-cluster", {
+            version: eks.KubernetesVersion.V1_19,
             clusterName: "sls-eks",
             vpc,
             mastersRole,
@@ -57,7 +58,7 @@ class ServerlessEKSStack extends cdk.Stack {
             8080, //container port,
             2 //replica number
         );
-        cluster.addResource("api-resource", ...apiTemplates);
+        cluster.addManifest("api-resource", ...apiTemplates);
 
         const graphqlTemplates = getKubernetesTemplates(
             graphqlAPIRepo, //repo
@@ -65,7 +66,7 @@ class ServerlessEKSStack extends cdk.Stack {
             8090, //container port,
             2 //replica number
         );
-        cluster.addResource("graphql-resource", ...graphqlTemplates);
+        cluster.addManifest("graphql-resource", ...graphqlTemplates);
     }
 }
 


### PR DESCRIPTION
errors were thrown when I ran through `serverless-eks` subfolder with `cdk bootstrap` step:
```
Argument of type '{ clusterName: string; vpc: ec2.Vpc; mastersRole: iam.Role; coreDnsComputeType: eks.CoreDnsComputeType.FARGATE; defaultProfile: { fargateProfileName: string; selectors: { namespace: string; }[]; podExecutionRole: iam.Role; }; }' is not assignable to parameter of type 'FargateClusterProps'.
Property 'version' is missing in type '{ clusterName: string; vpc: ec2.Vpc; mastersRole: iam.Role; coreDnsComputeType: eks.CoreDnsComputeType.FARGATE; defaultProfile: { fargateProfileName: string; selectors: { namespace: string; }[]; podExecutionRole: iam.Role; }; }' but required in type 'FargateClusterProps'.
```
and 
```
Property 'addResource' does not exist on type 'FargateCluster'.
```